### PR TITLE
Add support for methods

### DIFF
--- a/numpydoc_decorator/impl.py
+++ b/numpydoc_decorator/impl.py
@@ -29,7 +29,9 @@ def format_parameters(parameters, sig):
     docstring = ""
     # display parameters in order given in function signature
     for param_name, param in sig.parameters.items():
-        docstring += param_name.strip()
+        if param_name == "self":
+            continue
+        docstring += param_name
         if param.annotation is not Parameter.empty:
             docstring += f" : {format_type(param.annotation)}"
         docstring += newline
@@ -138,7 +140,7 @@ def doc(
         # check parameters against function signature
         sig = signature(f)
         for e in sig.parameters:
-            if e not in parameters:
+            if e != "self" and e not in parameters:
                 raise DocumentationError(f"Parameter {e} not documented.")
         for g in parameters:
             if g not in sig.parameters:

--- a/tests/test_numpydoc_decorator.py
+++ b/tests/test_numpydoc_decorator.py
@@ -571,7 +571,47 @@ def test_extended_summary():
     compare(actual, expected)
 
 
-# TODO methods
+def test_method():
+    class Foo:
+        # noinspection PyUnusedLocal
+        @doc(
+            summary="A method with simple parameters.",
+            parameters={
+                "bar": "This is very bar.",
+                "baz": "This is totally baz.",
+            },
+            returns={
+                "qux": "Amazingly qux.",
+            },
+        )
+        def m(self, bar, baz):
+            pass
+
+    foo = Foo()
+
+    expected = cleandoc(
+        """
+    A method with simple parameters.
+
+    Parameters
+    ----------
+    bar
+        This is very bar.
+    baz
+        This is totally baz.
+
+    Returns
+    -------
+    qux
+        Amazingly qux.
+    """
+    )
+    actual = getdoc(Foo.m)
+    compare(actual, expected)
+    actual = getdoc(foo.m)
+    compare(actual, expected)
+
+
 # TODO default values
 # TODO yields
 # TODO receives


### PR DESCRIPTION
Support documenting methods, basically involves ignoring the "self" parameter.