### PR TITLE
Allow extra parameters

### DIFF
--- a/numpydoc_decorator/impl.py
+++ b/numpydoc_decorator/impl.py
@@ -447,21 +447,14 @@ def doc(
     def decorator(f: Callable) -> Callable:
         docstring = ""
 
-        # check parameters against function signature
+        # check for missing parameters
         sig = signature(f)
         for e in sig.parameters:
             if e != "self" and e not in all_parameters:
                 raise DocumentationError(f"Parameter {e} not documented.")
-        for g in parameters:
-            if g not in sig.parameters:
-                raise DocumentationError(
-                    f"Parameter {g} not found in function signature."
-                )
-        for g in other_parameters:
-            if g not in sig.parameters:
-                raise DocumentationError(
-                    f"Other parameter {g} not found in function signature."
-                )
+
+        # N.B., intentionally allow extra parameters which are not in the
+        # signature - this can be convenient for the user.
 
         # add summary
         if summary:

--- a/tests/test_numpydoc_decorator.py
+++ b/tests/test_numpydoc_decorator.py
@@ -206,21 +206,45 @@ def test_missing_params():
 
 
 def test_extra_param():
-    with pytest.raises(DocumentationError):
-        # noinspection PyUnusedLocal
-        @doc(
-            summary="A function with simple parameters.",
-            parameters=dict(
-                bar="This is very bar.",
-                baz="This is totally baz.",
-                spam="This parameter is not in the signature.",
-            ),
-            returns=dict(
-                qux="Amazingly qux.",
-            ),
-        )
-        def foo(bar, baz):
-            pass
+    # Be relaxed about this, can be convenient because it allows chucking in
+    # everything from a bag of parameters, and only those which are in the
+    # function signature are used.
+
+    # noinspection PyUnusedLocal
+    @doc(
+        summary="A function with simple parameters.",
+        parameters=dict(
+            bar="This is very bar.",
+            baz="This is totally baz.",
+            spam="This parameter is not in the signature.",
+        ),
+        returns=dict(
+            qux="Amazingly qux.",
+        ),
+    )
+    def foo(bar, baz):
+        pass
+
+    expected = cleandoc(
+        """
+    A function with simple parameters.
+
+    Parameters
+    ----------
+    bar :
+        This is very bar.
+    baz :
+        This is totally baz.
+
+    Returns
+    -------
+    qux :
+        Amazingly qux.
+    """
+    )
+    actual = getdoc(foo)
+    compare(actual, expected)
+    validate(foo)
 
 
 def test_parameter_order():
@@ -1653,24 +1677,50 @@ def test_other_parameters_typed():
 
 
 def test_extra_other_param():
-    with pytest.raises(DocumentationError):
-        # noinspection PyUnusedLocal
-        @doc(
-            summary="A function with simple parameters.",
-            parameters=dict(
-                bar="This is very bar.",
-                baz="This is totally baz.",
-            ),
-            returns=dict(
-                qux="Amazingly qux.",
-            ),
-            other_parameters=dict(
-                spam="You'll love it.",
-                eggs="Good with spam.",
-            ),
-        )
-        def foo(bar, baz, spam):
-            pass
+    # noinspection PyUnusedLocal
+    @doc(
+        summary="A function with other parameters.",
+        parameters=dict(
+            bar="This is very bar.",
+            baz="This is totally baz.",
+        ),
+        returns=dict(
+            qux="Amazingly qux.",
+        ),
+        other_parameters=dict(
+            spam="You'll love it.",
+            eggs="Good with spam.",
+        ),
+    )
+    def foo(bar, baz, spam):
+        pass
+
+    expected = cleandoc(
+        """
+    A function with other parameters.
+
+    Parameters
+    ----------
+    bar :
+        This is very bar.
+    baz :
+        This is totally baz.
+
+    Returns
+    -------
+    qux :
+        Amazingly qux.
+
+    Other Parameters
+    ----------------
+    spam :
+        You'll love it.
+
+    """
+    )
+    actual = getdoc(foo)
+    compare(actual, expected)
+    validate(foo)
 
 
 def test_missing_other_param():


### PR DESCRIPTION
Be a bit more relaxed, don't raise an error if extra parameters are provided which are not in the function signature. 

This is a useful feature, because the user can throw in a bag of common parameters, and only those which are needed for each function are pulled out and used.